### PR TITLE
Add E2E test job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,22 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::747582436141:role/aws-iam-policy-sim-E2E
+          aws-region: ap-northeast-1
+      - name: Build
+        run: go build -o aws-iam-policy-sim .
+      - name: Run E2E test
+        run: ./aws-iam-policy-sim --role-name futosuto-deploy < e2e/statement.json

--- a/e2e/statement.json
+++ b/e2e/statement.json
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::sugarheart.utgw.net"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::sugarheart.utgw.net/futosuto/*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `e2e` job to CI workflow that runs `aws-iam-policy-sim` against a real AWS environment
- Use OIDC to assume `arn:aws:iam::747582436141:role/aws-iam-policy-sim-E2E` — no long-lived credentials needed
- Add `e2e/statement.json` as the input fixture for the E2E test

## Test plan

- [x] Confirm the `e2e` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)