### PR TITLE
Replace slog.Any error logging with slogerr.Error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/iam v1.54.4
 	github.com/lmittmann/tint v1.1.3
+	github.com/utgwkk/slogerr v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,3 +38,5 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
 github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/utgwkk/slogerr v0.1.0 h1:/qXJtdVwIOWBI++iterrXLlPNyuIGouU2I5Rd7UNBnY=
+github.com/utgwkk/slogerr v0.1.0/go.mod h1:LSmKlY6Svk1WKlTk8z3pUsbqqPMNJEYiPOZ5NHVvDUA=

--- a/internal/awsclient/simulate_custom_policy.go
+++ b/internal/awsclient/simulate_custom_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/input"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/slogx"
+	"github.com/utgwkk/slogerr"
 )
 
 func (c *Client) SimulateIAMRolePolicies(ctx context.Context, roleName string, normalizedStmts []*input.NormalizedStatement) (bool, error) {
@@ -27,7 +28,7 @@ func (c *Client) SimulateIAMRolePolicies(ctx context.Context, roleName string, n
 	for res, err := range c.simulateCustomPolicies(ctx, normalizedStmts, policyDocuments) {
 		action, resource := *res.EvalActionName, *res.EvalResourceName
 		if err != nil {
-			slogx.FatalContext(ctx, "Failed to simulate custom policy", slog.Any("error", err))
+			slogx.FatalContext(ctx, "Failed to simulate custom policy", slogerr.Error(err))
 		}
 
 		decisionType := res.EvalDecision

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/utgwkk/aws-iam-policy-sim/internal/awsclient"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/input"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/slogx"
+	"github.com/utgwkk/slogerr"
 )
 
 type CLI struct {
@@ -26,13 +27,13 @@ func (c *CLI) Do(ctx context.Context) {
 
 	client, err := awsclient.New(ctx)
 	if err != nil {
-		slogx.FatalContext(ctx, "Failed to initialize client", slog.Any("error", err))
+		slogx.FatalContext(ctx, "Failed to initialize client", slogerr.Error(err))
 	}
 
 	simulateInput := &input.Input{}
 	slog.DebugContext(ctx, "Reading input from STDIN")
 	if err := json.NewDecoder(os.Stdin).Decode(&simulateInput); err != nil {
-		slogx.FatalContext(ctx, "Failed to read input from STDIN", slog.Any("error", err))
+		slogx.FatalContext(ctx, "Failed to read input from STDIN", slogerr.Error(err))
 	}
 	slog.DebugContext(ctx, "Input decoded", slog.Int("numSimulates", len(simulateInput.Statement)))
 	if len(simulateInput.Statement) == 0 {
@@ -43,14 +44,14 @@ func (c *CLI) Do(ctx context.Context) {
 	for i, stmt := range simulateInput.Statement {
 		normalized, err := stmt.Normalize()
 		if err != nil {
-			slogx.FatalContext(ctx, "Error when normalizing input", slog.Int("index", i), slog.Any("error", err))
+			slogx.FatalContext(ctx, "Error when normalizing input", slog.Int("index", i), slogerr.Error(err))
 		}
 		normalizedStmts[i] = normalized
 	}
 
 	anyFailed, err := client.SimulateIAMRolePolicies(ctx, targetRoleName, normalizedStmts)
 	if err != nil {
-		slogx.FatalContext(ctx, "Failed to simulate", slog.Any("error", err))
+		slogx.FatalContext(ctx, "Failed to simulate", slogerr.Error(err))
 	}
 
 	if anyFailed {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/cli"
 	"github.com/utgwkk/aws-iam-policy-sim/internal/slogx"
+	"github.com/utgwkk/slogerr"
 )
 
 func main() {
@@ -26,10 +27,10 @@ func main() {
 	var cli cli.CLI
 	parser, err := kong.New(&cli)
 	if err != nil {
-		slogx.FatalContext(ctx, "failed to initialize kong parser", slog.Any("error", err))
+		slogx.FatalContext(ctx, "failed to initialize kong parser", slogerr.Error(err))
 	}
 	if _, err := parser.Parse(os.Args[1:]); err != nil {
-		slogx.FatalContext(ctx, "failed to parse args", slog.Any("error", err))
+		slogx.FatalContext(ctx, "failed to parse args", slogerr.Error(err))
 	}
 
 	cli.Do(ctx)


### PR DESCRIPTION
## Summary
This PR replaces all instances of `slog.Any("error", err)` with `slogerr.Error(err)` throughout the codebase for more consistent and idiomatic error logging.

## Key Changes
- Added `github.com/utgwkk/slogerr` dependency
- Updated error logging in `internal/cli/cli.go` (4 occurrences)
- Updated error logging in `main.go` (2 occurrences)
- Updated error logging in `internal/awsclient/simulate_custom_policy.go` (1 occurrence)

## Implementation Details
The `slogerr.Error()` function provides a more specialized and cleaner way to log errors compared to the generic `slog.Any()` approach. This change improves code consistency and likely provides better error formatting in structured logs.

https://claude.ai/code/session_0121oSFNSwUfZWBN7TZEEhEu