### PR TITLE
Group AWS SDK Go v2 dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
Configure Dependabot to group all AWS SDK Go v2 dependencies together, reducing the number of separate pull requests created for updates to this dependency family.

## Changes
- Added a new dependency group configuration for `aws-sdk-go-v2` in `.github/dependabot.yml`
- Configured the group to match all packages matching the pattern `github.com/aws/aws-sdk-go-v2*`
- This ensures all AWS SDK Go v2 updates are bundled into a single pull request rather than creating individual PRs for each module

## Benefits
- Reduces PR noise from frequent AWS SDK updates
- Simplifies dependency management by grouping related packages
- Makes it easier to review and test AWS SDK updates as a cohesive unit

https://claude.ai/code/session_01167NGV5mZXA6AiFfg7R6Dv