### PR TITLE
Enable exhaustruct_v5 linter in golangci configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - depguard
     - err113
     - exhaustruct
+    - exhaustruct_v5
     - funlen
     - gochecknoglobals
     - gocritic


### PR DESCRIPTION
## Summary
Added the `exhaustruct_v5` linter to the golangci-lint configuration to enforce exhaustive struct initialization checks.

## Changes
- Enabled `exhaustruct_v5` linter in `.golangci.yml` alongside the existing `exhaustruct` linter

## Details
The `exhaustruct_v5` linter is now active in the linting pipeline. This linter ensures that all struct fields are explicitly initialized when creating struct instances, helping prevent bugs caused by uninitialized fields and improving code clarity. The addition complements the existing `exhaustruct` linter configuration.

https://claude.ai/code/session_01A45DRuvw77nbj8m8pXUzzW